### PR TITLE
GitHub contributions の追加

### DIFF
--- a/components/commons/icons/index.ts
+++ b/components/commons/icons/index.ts
@@ -1,7 +1,7 @@
-import { AiFillHome as HomeIcon } from 'react-icons/ai'
+import { AiFillHome as HomeIcon, AiFillGithub as GithubIcon } from 'react-icons/ai'
 import { BiMenuAltLeft as MenuIcon } from 'react-icons/bi'
 import { BsTwitter as TwitterIcon } from 'react-icons/bs'
 import { FaBlogger as BlogsIcon } from 'react-icons/fa'
 import { TbExternalLink as ExternalLinkIcon } from 'react-icons/tb'
 
-export { HomeIcon, MenuIcon, BlogsIcon, TwitterIcon, ExternalLinkIcon }
+export { GithubIcon, HomeIcon, MenuIcon, BlogsIcon, TwitterIcon, ExternalLinkIcon }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,10 @@
 import SinglePost from '@/components/Post/SinglePost'
 import Tag from '@/components/Tag/Tag'
+import { GithubIcon } from '@/components/commons/icons'
 import { getAllPosts, getAllTags, getPostsForTopPage } from '@/lib/notionAPI'
 import { GetStaticProps } from 'next'
 import Link from 'next/link'
+import Image from 'next/image'
 
 export const getStaticProps: GetStaticProps = async () => {
   const fourPosts = await getPostsForTopPage(4)
@@ -34,10 +36,36 @@ export default function Home({ fourPosts, allTags }: any) {
             />
           </div>
         ))}
-        <Link href="/posts/page/1" className="mb-6 lg:w-1/2 mx-auto px-5 block text-right">
+        <Link
+          href="/posts/page/1"
+          className="mb-6 lg:w-1/2 mx-auto px-5 block text-right"
+        >
           ...もっと見る
         </Link>
         <Tag tags={allTags} />
+
+        <div className="mx-4">
+          <h2 className="flex items-center gap-1 text-lg font-bold">
+            <GithubIcon size={20} />
+            GitHub Contributions
+          </h2>
+          <Link
+            href="https://github.com/tkm-mkzk"
+            target="_blank"
+            rel="noopener"
+            className="relative mx-auto block h-32 w-full mt-2 mb-8 bg-blue-100 rounded-md cursor-pointer shadow-2xl hover:shadow-none hover:translate-y-1 duration-300 transition-all sp:h-20"
+          >
+            <Image
+              className="h-full w-full object-contain"
+              src="https://github-contributions-api.deno.dev/tkm-mkzk.svg?no-legend=true&no-total=true&scheme=blue"
+              alt="GitHub Contributions"
+              fill
+              sizes="800px"
+              priority
+              unoptimized
+            />
+          </Link>
+        </div>
       </main>
     </div>
   )


### PR DESCRIPTION
## イシュー番号
* Fix #7 

## やったこと
* GitHub contributions の追加

## やらないこと
* なし

## できるようになること（ユーザ目線）
* github contributions をTOP画面にSVGで表示し、githubプロフィールページに遷移できる。

## できなくなること（ユーザ目線）
* なし

## チェック項目
 - [ ] `npm run lint`でエラーがでないことを確認

## その他
* 参考：https://zenn.dev/kawarimidoll/articles/b573f617a51c0b
